### PR TITLE
This is missing, how?

### DIFF
--- a/TFB-Factions/plugins/TAB/config.yml
+++ b/TFB-Factions/plugins/TAB/config.yml
@@ -106,6 +106,7 @@ scoreboard:
   - disabledworld
   scoreboards:
     admin:
+      display-condition: permission:tab.scoreboard.admin
       title: Admin scoreboard
       lines:
       - '&6Network:'


### PR DESCRIPTION
This is a hotfix to fix defaults being able to view admin scoreboard on Factions