### PR TITLE
Install Coreprotect on Factions and Vanilla

### DIFF
--- a/TFB-Factions/build.gradle
+++ b/TFB-Factions/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'BuycraftX:BuycraftX:12.0.8'
     implementation 'ChatControlRed:ChatControlRed:10.16.11'
     implementation 'CommandPanels:CommandPanels:3.18.3.0'
+    implementation 'CoreProtect:CoreProtect:21.3'
     implementation 'DecentHolograms:DecentHolograms:2.7.11'
     implementation 'Essentials:Essentials:2.19.7'
     implementation 'EssentialsAntiBuild:EssentialsAntiBuild:2.19.7'

--- a/TFB-Vanilla/build.gradle
+++ b/TFB-Vanilla/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'ChatControlRed:ChatControlRed:10.16.11'
     implementation 'CommandPanels:CommandPanels:3.18.3.0'
     implementation 'DecentHolograms:DecentHolograms:2.7.11'
+    implementation 'CoreProtect:CoreProtect:21.3'
     implementation 'Essentials:Essentials:2.19.7'
     implementation 'EssentialsAntiBuild:EssentialsAntiBuild:2.19.7'
     implementation 'EssentialsChat:EssentialsChat:2.19.7'


### PR DESCRIPTION
We are having an issue #165 on Factions where mobs with no nametags are despawning. 
We will use Coreprotect to inspect if we can see anything causing this.