### PR TITLE
Disabled tick-limiter as it crashes servers

### DIFF
--- a/TFB-Creative/plugins/FastAsyncWorldEdit/config.yml
+++ b/TFB-Creative/plugins/FastAsyncWorldEdit/config.yml
@@ -58,7 +58,7 @@ lighting:
 # Generic tick limiter (not necessarily WorldEdit related, but useful to stop abuse)
 tick-limiter:
   # Enable the limiter
-  enabled: true
+  enabled: false
   # The interval in ticks
   interval: 20
   # Max falling blocks per interval (per chunk)

--- a/TFB-Factions/plugins/FastAsyncWorldEdit/config.yml
+++ b/TFB-Factions/plugins/FastAsyncWorldEdit/config.yml
@@ -58,7 +58,7 @@ lighting:
 # Generic tick limiter (not necessarily WorldEdit related, but useful to stop abuse)
 tick-limiter:
   # Enable the limiter
-  enabled: true
+  enabled: false
   # The interval in ticks
   interval: 20
   # Max falling blocks per interval (per chunk)

--- a/TFB-Lobby/plugins/FastAsyncWorldEdit/config.yml
+++ b/TFB-Lobby/plugins/FastAsyncWorldEdit/config.yml
@@ -58,7 +58,7 @@ lighting:
 # Generic tick limiter (not necessarily WorldEdit related, but useful to stop abuse)
 tick-limiter:
   # Enable the limiter
-  enabled: true
+  enabled: false
   # The interval in ticks
   interval: 20
   # Max falling blocks per interval (per chunk)

--- a/TFB-Parkour/plugins/FastAsyncWorldEdit/config.yml
+++ b/TFB-Parkour/plugins/FastAsyncWorldEdit/config.yml
@@ -58,7 +58,7 @@ lighting:
 # Generic tick limiter (not necessarily WorldEdit related, but useful to stop abuse)
 tick-limiter:
   # Enable the limiter
-  enabled: true
+  enabled: false
   # The interval in ticks
   interval: 20
   # Max falling blocks per interval (per chunk)

--- a/TFB-Vanilla/plugins/FastAsyncWorldEdit/config.yml
+++ b/TFB-Vanilla/plugins/FastAsyncWorldEdit/config.yml
@@ -58,7 +58,7 @@ lighting:
 # Generic tick limiter (not necessarily WorldEdit related, but useful to stop abuse)
 tick-limiter:
   # Enable the limiter
-  enabled: true
+  enabled: false
   # The interval in ticks
   interval: 20
   # Max falling blocks per interval (per chunk)


### PR DESCRIPTION
Vanilla keeps crashing with the error written in the issue, they say it should fix it by disable the setting and since its not important, we disable it.