### PR TITLE
Add Spark to all servers

### DIFF
--- a/TFB-Creative/build.gradle
+++ b/TFB-Creative/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'ProtocolLib:ProtocolLib:5.0.0'
     implementation 'SuperVanish:SuperVanish:6.2.16'
+    implementation 'spark:spark:1.10.41'
     implementation 'TAB:TAB:3.3.2'
     implementation 'Vault:Vault:1.7.3-b131'
     implementation 'ViaBackwards:ViaBackwards:4.6.1'

--- a/TFB-Factions/build.gradle
+++ b/TFB-Factions/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'ProtocolLib:ProtocolLib:5.0.0'
     implementation 'SuperVanish:SuperVanish:6.2.16'
+    implementation 'spark:spark:1.10.41'
     implementation 'TAB:TAB:3.3.2'
     implementation 'Vault:Vault:1.7.3-b131'
     implementation 'ViaBackwards:ViaBackwards:4.6.1'

--- a/TFB-Flamecord/build.gradle
+++ b/TFB-Flamecord/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'BungeeControl-Red:BungeeControl-Red:3.14.4'
     implementation 'BuycraftX-Bungee:BuycraftX-Bungee:12.0.8'
     implementation 'LuckPerms-Bungee:LuckPerms-Bungee:5.4.79'
+    implementation 'spark:BungeeSpark:1.10.41'
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'Reconnect:Reconnect:1.6.6'
     implementation 'VulcanBungee:VulcanBungee:1.0.6'

--- a/TFB-Lobby/build.gradle
+++ b/TFB-Lobby/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'ProtocolLib:ProtocolLib:5.0.0'
     implementation 'SuperVanish:SuperVanish:6.2.16'
+    implementation 'spark:spark:1.10.41'
     implementation 'TAB:TAB:3.3.2'
     implementation 'Vault:Vault:1.7.3-b131'
     implementation 'ViaBackwards:ViaBackwards:4.6.1'

--- a/TFB-Parkour/build.gradle
+++ b/TFB-Parkour/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'ProtocolLib:ProtocolLib:5.0.0'
     implementation 'SuperVanish:SuperVanish:6.2.16'
+    implementation 'spark:spark:1.10.41'
     implementation 'TAB:TAB:3.3.2'
     implementation 'Vault:Vault:1.7.3-b131'
     implementation 'ViaBackwards:ViaBackwards:4.6.1'

--- a/TFB-Vanilla/build.gradle
+++ b/TFB-Vanilla/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'Plan:Plan:5.5-build-2391'
     implementation 'ProtocolLib:ProtocolLib:5.0.0'
     implementation 'SuperVanish:SuperVanish:6.2.16'
+    implementation 'spark:spark:1.10.41'
     implementation 'TAB:TAB:3.3.2'
     implementation 'Vault:Vault:1.7.3-b131'
     implementation 'ViaBackwards:ViaBackwards:4.6.1'


### PR DESCRIPTION
The Spark plugin (https://spark.lucko.me/) probably made by the same developer of LuckPerms, have made this plugin as a Minecraft profiler so we can debug why servers lag/crash etc. It is supposed to replace Paper's default profiler so I assume it's time for us to get used to it. 
![image](https://github.com/theflyingbirdsmc/TFB-Network/assets/6181362/c7fcd810-fb67-406a-a2b6-091778a911f8)

With this PR approved I hopefully can debug why Vanilla keeps crashing...