### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/creative/plugins/ChatControlRed/localization/messages_en.yml
+++ b/creative/plugins/ChatControlRed/localization/messages_en.yml
@@ -5,7 +5,7 @@
 #   Here you can customize 99% of all plugin messages and tooltips.
 #
 #   1) COLOR CODES are supported with the '&' character.
-#      - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#      - For usage, see http://minecraft.wiki/w/Formatting_codes
 #      - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/creative/plugins/ChatControlRed/settings.yml
+++ b/creative/plugins/ChatControlRed/settings.yml
@@ -8,7 +8,7 @@
 # !-----------------------------------------------------------------------------------------------!
 #
 #    1) COLOR CODES are supported with the '&' character.
-#       - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#       - For usage, see http://minecraft.wiki/w/Formatting_codes
 #       - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/creative/plugins/LuckPerms/config.yml
+++ b/creative/plugins/LuckPerms/config.yml
@@ -691,5 +691,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Commands#Target_selectors
 resolve-command-selectors: false

--- a/factions/plugins/ChatControlRed/localization/messages_en.yml
+++ b/factions/plugins/ChatControlRed/localization/messages_en.yml
@@ -5,7 +5,7 @@
 #   Here you can customize 99% of all plugin messages and tooltips.
 #
 #   1) COLOR CODES are supported with the '&' character.
-#      - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#      - For usage, see http://minecraft.wiki/w/Formatting_codes
 #      - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/factions/plugins/ChatControlRed/settings.yml
+++ b/factions/plugins/ChatControlRed/settings.yml
@@ -8,7 +8,7 @@
 # !-----------------------------------------------------------------------------------------------!
 #
 #    1) COLOR CODES are supported with the '&' character.
-#       - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#       - For usage, see http://minecraft.wiki/w/Formatting_codes
 #       - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/factions/plugins/LuckPerms/config.yml
+++ b/factions/plugins/LuckPerms/config.yml
@@ -691,5 +691,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Commands#Target_selectors
 resolve-command-selectors: false

--- a/lobby/plugins/ChatControlRed/localization/messages_en.yml
+++ b/lobby/plugins/ChatControlRed/localization/messages_en.yml
@@ -5,7 +5,7 @@
 #   Here you can customize 99% of all plugin messages and tooltips.
 #
 #   1) COLOR CODES are supported with the '&' character.
-#      - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#      - For usage, see http://minecraft.wiki/w/Formatting_codes
 #      - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/lobby/plugins/ChatControlRed/settings.yml
+++ b/lobby/plugins/ChatControlRed/settings.yml
@@ -8,7 +8,7 @@
 # !-----------------------------------------------------------------------------------------------!
 #
 #    1) COLOR CODES are supported with the '&' character.
-#       - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#       - For usage, see http://minecraft.wiki/w/Formatting_codes
 #       - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/lobby/plugins/DeluxeMenus/gui_menus/basics_menu.yml
+++ b/lobby/plugins/DeluxeMenus/gui_menus/basics_menu.yml
@@ -60,7 +60,7 @@ items:
   'teststone':
     #We will start to create a STONE item,
     material: STONE
-    # with a Block data set to 1, so that you can change stone type from STONE to GRANITE. More information about the block data can be checked through each items from Minecraft Wikipedia
+    # with a Block data set to 1, so that you can change stone type from STONE to GRANITE. More information about the block data can be checked through each items from the Minecraft wiki
     data: 1
     # Slots that you want to put the item. Starts from 0
     slot: 0

--- a/lobby/plugins/LuckPerms/config.yml
+++ b/lobby/plugins/LuckPerms/config.yml
@@ -691,5 +691,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Commands#Target_selectors
 resolve-command-selectors: false

--- a/parkour/plugins/ChatControlRed/localization/messages_en.yml
+++ b/parkour/plugins/ChatControlRed/localization/messages_en.yml
@@ -5,7 +5,7 @@
 #   Here you can customize 99% of all plugin messages and tooltips.
 #
 #   1) COLOR CODES are supported with the '&' character.
-#      - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#      - For usage, see http://minecraft.wiki/w/Formatting_codes
 #      - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/parkour/plugins/ChatControlRed/settings.yml
+++ b/parkour/plugins/ChatControlRed/settings.yml
@@ -8,7 +8,7 @@
 # !-----------------------------------------------------------------------------------------------!
 #
 #    1) COLOR CODES are supported with the '&' character.
-#       - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#       - For usage, see http://minecraft.wiki/w/Formatting_codes
 #       - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/parkour/plugins/LuckPerms/config.yml
+++ b/parkour/plugins/LuckPerms/config.yml
@@ -690,5 +690,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Commands#Target_selectors
 resolve-command-selectors: false

--- a/vanilla/plugins/ChatControlRed/localization/messages_en.yml
+++ b/vanilla/plugins/ChatControlRed/localization/messages_en.yml
@@ -5,7 +5,7 @@
 #   Here you can customize 99% of all plugin messages and tooltips.
 #
 #   1) COLOR CODES are supported with the '&' character.
-#      - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#      - For usage, see http://minecraft.wiki/w/Formatting_codes
 #      - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/vanilla/plugins/ChatControlRed/settings.yml
+++ b/vanilla/plugins/ChatControlRed/settings.yml
@@ -8,7 +8,7 @@
 # !-----------------------------------------------------------------------------------------------!
 #
 #    1) COLOR CODES are supported with the '&' character.
-#       - For usage, see http://minecraftwiki.net/wiki/Formatting_codes
+#       - For usage, see http://minecraft.wiki/w/Formatting_codes
 #       - When you use them, place quotes around the message like this: "Hello &cworld."
 #       - To use HEX colors, use #123456 syntax: "Hello #123456world."
 #

--- a/vanilla/plugins/LuckPerms/config.yml
+++ b/vanilla/plugins/LuckPerms/config.yml
@@ -691,5 +691,5 @@ update-client-command-list: true
 register-command-list-data: true
 
 # If LuckPerms should attempt to resolve Vanilla command target selectors for LP commands.
-# See here for more info: https://minecraft.gamepedia.com/Commands#Target_selectors
+# See here for more info: https://minecraft.wiki/w/Commands#Target_selectors
 resolve-command-selectors: false


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.